### PR TITLE
fix: only count products towards discount that are not optional or optional and selected

### DIFF
--- a/product-bundles-bulk-discounts-for-woocommerce.php
+++ b/product-bundles-bulk-discounts-for-woocommerce.php
@@ -471,9 +471,12 @@ class WC_PB_Bulk_Discounts {
 
 				$bundled_items_data = $container[ 'stamp' ];
 				$total_quantity     = 0;
+				$bundled_items      = $container[ 'data' ]->get_bundled_items();
 
-				foreach ( $bundled_items_data as $bundled_item_data ) {
-					if ( isset( $bundled_item_data[ 'quantity' ] ) ) {
+				foreach ( $bundled_items_data as $bundled_item_id => $bundled_item_data ) {
+					$bundled_item = $bundled_items[ $bundled_item_id ];
+
+					if ( isset( $bundled_item_data[ 'quantity' ] ) && ( ! $bundled_item->is_optional() || ( isset( $bundled_item_data[ 'optional_selected' ] ) && $bundled_item_data[ 'optional_selected' ] === 'yes' ) ) ) {
 						$total_quantity += $bundled_item_data[ 'quantity' ];
 					}
 				}
@@ -516,9 +519,12 @@ class WC_PB_Bulk_Discounts {
 
 				$bundled_items_data = $cart_item[ 'stamp' ];
 				$total_quantity     = 0;
+				$bundled_items      = $cart_item[ 'data' ]->get_bundled_items();
 
-				foreach ( $bundled_items_data as $bundled_item_data ) {
-					if ( isset( $bundled_item_data[ 'quantity' ] ) ) {
+				foreach ( $bundled_items_data as $bundled_item_id => $bundled_item_data ) {
+					$bundled_item = $bundled_items[ $bundled_item_id ];
+
+					if ( isset( $bundled_item_data[ 'quantity' ] ) && ( ! $bundled_item->is_optional() || ( isset( $bundled_item_data[ 'optional_selected' ] ) && $bundled_item_data[ 'optional_selected' ] === 'yes' ) ) ) {
 						$total_quantity += $bundled_item_data[ 'quantity' ];
 					}
 				}

--- a/product-bundles-bulk-discounts-for-woocommerce.php
+++ b/product-bundles-bulk-discounts-for-woocommerce.php
@@ -471,12 +471,9 @@ class WC_PB_Bulk_Discounts {
 
 				$bundled_items_data = $container[ 'stamp' ];
 				$total_quantity     = 0;
-				$bundled_items      = $container[ 'data' ]->get_bundled_items();
 
-				foreach ( $bundled_items_data as $bundled_item_id => $bundled_item_data ) {
-					$bundled_item = $bundled_items[ $bundled_item_id ];
-
-					if ( isset( $bundled_item_data[ 'quantity' ] ) && ( ! $bundled_item->is_optional() || ( isset( $bundled_item_data[ 'optional_selected' ] ) && $bundled_item_data[ 'optional_selected' ] === 'yes' ) ) ) {
+				foreach ( $bundled_items_data as $bundled_item_data ) {
+					if ( isset( $bundled_item_data[ 'quantity' ] ) && ( ! isset( $bundled_item_data[ 'optional_selected' ] ) || $bundled_item_data[ 'optional_selected' ] === 'yes' ) ) {
 						$total_quantity += $bundled_item_data[ 'quantity' ];
 					}
 				}
@@ -519,12 +516,9 @@ class WC_PB_Bulk_Discounts {
 
 				$bundled_items_data = $cart_item[ 'stamp' ];
 				$total_quantity     = 0;
-				$bundled_items      = $cart_item[ 'data' ]->get_bundled_items();
 
-				foreach ( $bundled_items_data as $bundled_item_id => $bundled_item_data ) {
-					$bundled_item = $bundled_items[ $bundled_item_id ];
-
-					if ( isset( $bundled_item_data[ 'quantity' ] ) && ( ! $bundled_item->is_optional() || ( isset( $bundled_item_data[ 'optional_selected' ] ) && $bundled_item_data[ 'optional_selected' ] === 'yes' ) ) ) {
+				foreach ( $bundled_items_data as $bundled_item_data ) {
+					if ( isset( $bundled_item_data[ 'quantity' ] ) && ( ! isset( $bundled_item_data[ 'optional_selected' ] ) || $bundled_item_data[ 'optional_selected' ] === 'yes' ) ) {
 						$total_quantity += $bundled_item_data[ 'quantity' ];
 					}
 				}


### PR DESCRIPTION
Should resolve #22.

Only counts products into the total_quantity if they are
a. Not optional OR
b. have `optional_selected === 'yes'` set.

This solution seems to work for our cases, but please validate on your own.