### PR TITLE
Declared compatibility with HPOS and added compatibility with the block-based Single Product template

### DIFF
--- a/readme.txt
+++ b/readme.txt
@@ -5,7 +5,7 @@ Tags: woocommerce, product, bundles, bulk, discount, quantity, tiers, rules
 Requires at least: 4.4
 Tested up to: 5.7
 Requires PHP: 5.6
-Stable tag: 1.3.9
+Stable tag: 1.4.0
 WC requires at least: 3.1
 WC tested up to: 5.4
 License: GNU General Public License v3.0
@@ -88,6 +88,10 @@ This plugin requires the official [WooCommerce Product Bundles](https://woocomme
 
 
 == Changelog ==
+
+= 1.4.0 =
+* Feature - Added compatibility with the new block-based Single Product Template.
+* Feature - Declared compatibility with the new High-Performance Order Tables. 
 
 = 1.3.9 =
 * Feature - Added support for the WooCommerce Importer/Exporter.


### PR DESCRIPTION
### Description

This PR declared compatibility with new High-Performance Order tables and adds compatibility with the new block-based Single Product template by fixing the way the BD script is enqueued. 

closes #28 

### Testing steps

1. Enable HPOS under WooCommerce > Settings > Advanced. 
2. Ensure that Bulk Discounts doesn't show up as an incompatible plugin. 
3. Update to WooCommerce 7.9+.
4. Use a block-based theme such as Twenty Twenty Three. 
5. Create a Bundle with a Bulk Discount rule. 
6. Ensure that the discount info show up in the single product page. 